### PR TITLE
Anime ranked will no longer raise AttributeError

### DIFF
--- a/animec/anicore.py
+++ b/animec/anicore.py
@@ -91,7 +91,8 @@ class Anime:
         favorites = self._parent_(element = dark_text, txt = "Favorites:")
 
         ranked_text = str(anime_page.find('div', {'class':'spaceit po-r js-statistics-info di-ib'}))
-        ranked = re.search("#.*<", ranked_text).group().split("<")[0]
+        ranked = re.search("#.*<", ranked_text)
+        ranked = ranked.group().split("<")[0] if ranked else None
 
         description = anime_page.find('p', {'itemprop' : 'description'}).text
         poster = anime_page.find('img', {'itemprop' : 'image'})


### PR DESCRIPTION
### animec.anicore.Anime.ranked will now return None when the value on MAL's website is N/A

Before:
![before](https://user-images.githubusercontent.com/53869860/120789648-11ba0980-c55c-11eb-9aa1-924eb488bc44.png)

After:
![after](https://user-images.githubusercontent.com/53869860/120789678-1ed6f880-c55c-11eb-8a08-3f5e85b90a57.png)

I don't think raising an exception on this case is the best practice, but please kindly correct me if I'm wrong